### PR TITLE
chore: use latest miniflare

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
     "@graphql-tools/optimize": "^1.3.1",
     "@luckycatfactory/esbuild-graphql-loader": "^3.7.0",
     "esbuild": "^0.15.3",
-    "miniflare": "2.9.0",
-    "typescript": "^4.8.4",
-    "wrangler": "2.1.9"
+    "miniflare": "2.11.0",
+    "typescript": "^4.8.4"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
Also, there is a conflict with having wrangler as a dev dependency and trying to run, so remove it. Global install is preferred.