### PR TITLE
fix: Illegal Invocation error message when running on production

### DIFF
--- a/src/datasources/pokemon-api.ts
+++ b/src/datasources/pokemon-api.ts
@@ -1,10 +1,11 @@
+import type { Fetcher } from '@apollo/utils.fetcher';
 import type { KeyValueCache } from '@apollo/utils.keyvaluecache';
 import { RESTDataSource } from '@apollo/datasource-rest';
 
 class PokemonAPI extends RESTDataSource {
   override baseURL = 'https://pokeapi.co/api/v2/';
 
-  constructor(options: { cache: KeyValueCache }) {
+  constructor(options: { cache: KeyValueCache, fetch: Fetcher }) {
     super(options);
   }
 

--- a/src/handlers/apollo.ts
+++ b/src/handlers/apollo.ts
@@ -30,7 +30,7 @@ export const createGraphQLHandler = (options: GraphQLOptions): GraphQLRequestHan
       const cache = options.kvCache ? new KVCache() : server.cache;
 
       const dataSources: ApolloDataSources = {
-        pokemonAPI: new PokemonAPI({ cache }),
+        pokemonAPI: new PokemonAPI({ cache, fetch: fetch.bind(globalThis) }),
       };
 
       return { dataSources };


### PR DESCRIPTION
Found this error only once the worker was deployed on CF as using `miniflare` for local didn't reproduce the error. Related solution: https://github.com/supabase/supabase/issues/4417

To reproduce on local dev, use `wrangler dev` instead of `yarn dev`, then try to query a pokemon. Once using `wrangler dev`, press `l` to switch to local mode and magically, the issue goes away (without this fix).