### PR TITLE
Add deploy-prod task to use production env

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "generate": "graphql-codegen --config codegen.yml",
     "build": "NODE_ENV=production node worker.build.js",
     "dev": "miniflare --watch --debug --host 0.0.0.0 --kv GRAPHQL_CACHE",
-    "deploy": "wrangler publish"
+    "deploy": "wrangler publish",
+    "deploy-prod": "wrangler publish --env production"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20221111.1",


### PR DESCRIPTION
The default "deploy" task wasn't picking up the KV namespace value (and other production values), so adding a separate task for that to make it more clear for folks new to using wrangler.